### PR TITLE
Fix Safari Blazor crash and stabilize ACA service wiring

### DIFF
--- a/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/Commands/AddResponseCommand.cs
+++ b/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/Commands/AddResponseCommand.cs
@@ -18,6 +18,11 @@ public record AddResponseCommand(
 {
     public static async Task<ResultBox<EventOrNone>> HandleAsync(AddResponseCommand command, ICommandContext context)
     {
+        if (string.IsNullOrWhiteSpace(command.ClientId))
+        {
+            return ResultBox.FromException<EventOrNone>(new ArgumentException("Client ID cannot be empty"));
+        }
+
         var tag = new QuestionTag(command.QuestionId);
         var stateResult = await context.GetStateAsync<QuestionProjector>(tag);
         if (!stateResult.IsSuccess || stateResult.GetValue().Payload is not Question question)
@@ -40,15 +45,24 @@ public record AddResponseCommand(
             return ResultBox.FromException<EventOrNone>(new ArgumentException($"Option with ID '{command.SelectedOptionId}' does not exist"));
         }
 
-        if (!question.AllowMultipleResponses && question.Responses.Any(r => r.ClientId == command.ClientId))
+        var participantResponseTag = QuestionParticipantResponseTag.Create(command.QuestionId, command.ClientId);
+        if (!question.AllowMultipleResponses)
         {
-            return ResultBox.FromException<EventOrNone>(new InvalidOperationException("Multiple responses are not allowed for this question"));
+            var participantResponseStateResult =
+                await context.GetStateAsync<QuestionParticipantResponseProjector>(participantResponseTag);
+            if (participantResponseStateResult.IsSuccess &&
+                participantResponseStateResult.GetValue().Payload is QuestionParticipantResponse)
+            {
+                return ResultBox.FromException<EventOrNone>(
+                    new InvalidOperationException("Multiple responses are not allowed for this question"));
+            }
         }
 
         return EventOrNone.EventWithTags(
             new ResponseAdded(Guid.NewGuid(), command.ParticipantName, command.SelectedOptionId, command.Comment,
                 DateTime.UtcNow, command.ClientId),
             tag,
-            new QuestionGroupTag(question.QuestionGroupId));
+            new QuestionGroupTag(question.QuestionGroupId),
+            participantResponseTag);
     }
 }

--- a/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/Commands/UpdateResponseCommentCommand.cs
+++ b/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/Commands/UpdateResponseCommentCommand.cs
@@ -34,8 +34,16 @@ public record UpdateResponseCommentCommand(
             return ResultBox.FromException<EventOrNone>(new ArgumentException("Client ID cannot be empty"));
         }
 
-        var targetResponse = question.Responses.LastOrDefault(r => r.ClientId == command.ClientId);
-        if (targetResponse is null)
+        var participantResponseTag = QuestionParticipantResponseTag.Create(command.QuestionId, command.ClientId);
+        var participantResponseStateResult =
+            await context.GetStateAsync<QuestionParticipantResponseProjector>(participantResponseTag);
+        var targetResponseId = participantResponseStateResult.IsSuccess &&
+                               participantResponseStateResult.GetValue().Payload is QuestionParticipantResponse state
+            ? state.LastResponseId
+            : question.Responses
+                .LastOrDefault(r => r.ClientId == command.ClientId)
+                ?.Id;
+        if (targetResponseId is null || targetResponseId == Guid.Empty)
         {
             return ResultBox.FromException<EventOrNone>(
                 new InvalidOperationException("Cannot update comment because no response exists for this participant"));
@@ -43,11 +51,12 @@ public record UpdateResponseCommentCommand(
 
         return EventOrNone.EventWithTags(
             new ResponseCommentUpdated(
-                targetResponse.Id,
+                targetResponseId.Value,
                 command.ClientId,
                 command.Comment,
                 DateTime.UtcNow),
             tag,
-            new QuestionGroupTag(question.QuestionGroupId));
+            new QuestionGroupTag(question.QuestionGroupId),
+            participantResponseTag);
     }
 }

--- a/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/Payloads/QuestionParticipantResponse.cs
+++ b/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/Payloads/QuestionParticipantResponse.cs
@@ -1,0 +1,11 @@
+using Sekiban.Dcb.Tags;
+
+namespace EsCQRSQuestions.Domain.Aggregates.Questions.Payloads;
+
+[GenerateSerializer]
+public record QuestionParticipantResponse(
+    string ClientId,
+    Guid LastResponseId,
+    string LastSelectedOptionId,
+    string? LastComment,
+    DateTime LastTimestamp) : ITagStatePayload;

--- a/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/QuestionParticipantResponseProjector.cs
+++ b/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/QuestionParticipantResponseProjector.cs
@@ -1,0 +1,37 @@
+using EsCQRSQuestions.Domain.Aggregates.Questions.Events;
+using EsCQRSQuestions.Domain.Aggregates.Questions.Payloads;
+using Sekiban.Dcb.Events;
+using Sekiban.Dcb.Tags;
+
+namespace EsCQRSQuestions.Domain.Aggregates.Questions;
+
+public class QuestionParticipantResponseProjector : ITagProjector<QuestionParticipantResponseProjector>
+{
+    public static string ProjectorVersion => "1.0.0";
+    public static string ProjectorName => nameof(QuestionParticipantResponseProjector);
+
+    public static ITagStatePayload Project(ITagStatePayload current, Event ev) =>
+        (current, ev.Payload) switch
+        {
+            (EmptyTagStatePayload, ResponseAdded added) => new QuestionParticipantResponse(
+                added.ClientId,
+                added.ResponseId,
+                added.SelectedOptionId,
+                added.Comment,
+                added.Timestamp),
+            (QuestionParticipantResponse state, ResponseAdded added) => state with
+            {
+                LastResponseId = added.ResponseId,
+                LastSelectedOptionId = added.SelectedOptionId,
+                LastComment = added.Comment,
+                LastTimestamp = added.Timestamp
+            },
+            (QuestionParticipantResponse state, ResponseCommentUpdated updated)
+                when state.LastResponseId == updated.ResponseId || state.ClientId == updated.ClientId => state with
+            {
+                LastComment = updated.Comment,
+                LastTimestamp = updated.Timestamp
+            },
+            _ => current
+        };
+}

--- a/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/QuestionParticipantResponseTag.cs
+++ b/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Aggregates/Questions/QuestionParticipantResponseTag.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography;
+using System.Text;
+using Sekiban.Dcb.Tags;
+
+namespace EsCQRSQuestions.Domain.DcbTags;
+
+public record QuestionParticipantResponseTag(Guid QuestionParticipantResponseId) : IGuidTagGroup<QuestionParticipantResponseTag>
+{
+    public bool IsConsistencyTag() => true;
+    public static string TagGroupName => "QuestionParticipantResponse";
+    public static QuestionParticipantResponseTag FromContent(string content) => new(Guid.Parse(content));
+    public Guid GetId() => QuestionParticipantResponseId;
+
+    public static QuestionParticipantResponseTag Create(Guid questionId, string clientId) =>
+        new(CreateDeterministicId(questionId, clientId));
+
+    private static Guid CreateDeterministicId(Guid questionId, string clientId)
+    {
+        var normalizedClientId = (clientId ?? string.Empty).Trim().ToLowerInvariant();
+        var raw = $"{questionId:N}|{normalizedClientId}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+        var bytes = hash[..16].ToArray();
+        bytes[6] = (byte)((bytes[6] & 0x0F) | 0x50);
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
+        return new Guid(bytes);
+    }
+}

--- a/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Generated/EsCQRSQuestionsDomainDomainTypes.cs
+++ b/EsCQRSQuestions/EsCQRSQuestions.Domain/DcbMigrated/Generated/EsCQRSQuestionsDomainDomainTypes.cs
@@ -52,11 +52,13 @@ public static class EsCQRSQuestionsDomainDomainTypes
             types.EventTypes.RegisterEventType<WeatherForecastDeleted>();
 
             types.TagProjectorTypes.RegisterProjector<QuestionProjector>();
+            types.TagProjectorTypes.RegisterProjector<QuestionParticipantResponseProjector>();
             types.TagProjectorTypes.RegisterProjector<QuestionGroupProjector>();
             types.TagProjectorTypes.RegisterProjector<ActiveUsersProjector>();
             types.TagProjectorTypes.RegisterProjector<WeatherForecastProjector>();
 
             types.TagStatePayloadTypes.RegisterPayloadType<Question>();
+            types.TagStatePayloadTypes.RegisterPayloadType<QuestionParticipantResponse>();
             types.TagStatePayloadTypes.RegisterPayloadType<DeletedQuestion>();
             types.TagStatePayloadTypes.RegisterPayloadType<QuestionGroup>();
             types.TagStatePayloadTypes.RegisterPayloadType<DeletedQuestionGroup>();
@@ -65,12 +67,15 @@ public static class EsCQRSQuestionsDomainDomainTypes
             types.TagStatePayloadTypes.RegisterPayloadType<DeletedWeatherForecast>();
 
             types.TagTypes.RegisterTagGroupType<QuestionTag>();
+            types.TagTypes.RegisterTagGroupType<QuestionParticipantResponseTag>();
             types.TagTypes.RegisterTagGroupType<QuestionGroupTag>();
             types.TagTypes.RegisterTagGroupType<ActiveUsersTag>();
             types.TagTypes.RegisterTagGroupType<WeatherForecastTag>();
 
             types.MultiProjectorTypes.RegisterProjectorWithCustomSerialization<
                 GenericTagMultiProjector<QuestionProjector, QuestionTag>>();
+            types.MultiProjectorTypes.RegisterProjectorWithCustomSerialization<
+                GenericTagMultiProjector<QuestionParticipantResponseProjector, QuestionParticipantResponseTag>>();
             types.MultiProjectorTypes.RegisterProjectorWithCustomSerialization<
                 GenericTagMultiProjector<QuestionGroupProjector, QuestionGroupTag>>();
             types.MultiProjectorTypes.RegisterProjectorWithCustomSerialization<

--- a/EsCQRSQuestions/EsCQRSQuestions.Web/Components/Pages/QuestionairEn.razor
+++ b/EsCQRSQuestions/EsCQRSQuestions.Web/Components/Pages/QuestionairEn.razor
@@ -1,6 +1,5 @@
 @page "/questionair"
 @page "/questionair/{UniqueCode}"
-@attribute [StreamRendering(true)]
 @using EsCQRSQuestions.Domain.Aggregates.Questions.Queries
 @using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.Extensions.Logging
@@ -392,8 +391,6 @@
                                 <div class="comment-composer">
                                     <input type="text" class="form-control comment-input" id="comment"
                                            @bind="comment" @bind:event="oninput" @onkeydown="HandleCommentKeyDown"
-                                           @oncompositionstart="OnCommentCompositionStart"
-                                           @oncompositionend="OnCommentCompositionEnd"
                                            placeholder="Write a comment about this question" />
                                     <button class="btn btn-outline-primary comment-submit-btn"
                                             @onclick="SubmitCommentOnly"
@@ -502,7 +499,6 @@
     private bool hasSubmitted = false;
     private bool isSubmittingOption = false;
     private bool isSubmittingComment = false;
-    private bool isCommentComposing = false;
     private string inputUniqueCode = "";
     private bool isValidating = false;
     
@@ -511,6 +507,7 @@
     private CancellationTokenSource? autoRefreshCts;
     private Task? autoRefreshTask;
     private bool isAutoRefreshing;
+    private readonly SemaphoreSlim refreshLock = new(1, 1);
 
     // Previous UniqueCode to track changes
     private string? previousUniqueCode;
@@ -746,6 +743,7 @@
 
     private async Task RefreshActiveQuestion()
     {
+        await refreshLock.WaitAsync();
         try
         {
             
@@ -797,6 +795,10 @@
             {
                 errorMessage = "The survey code entered does not exist. Please check the code and try again.";
             }
+        }
+        finally
+        {
+            refreshLock.Release();
         }
     }
 
@@ -1037,7 +1039,7 @@
     private async Task HandleCommentKeyDown(KeyboardEventArgs e)
     {
         // Prevent accidental submit while IME composition is active (e.g. Japanese conversion).
-        if (isCommentComposing || e.IsComposing)
+        if (e.IsComposing)
         {
             return;
         }
@@ -1046,16 +1048,6 @@
         {
             await SubmitCommentOnly();
         }
-    }
-
-    private void OnCommentCompositionStart()
-    {
-        isCommentComposing = true;
-    }
-
-    private void OnCommentCompositionEnd()
-    {
-        isCommentComposing = false;
     }
 
     private void StartAutoRefresh()
@@ -1115,5 +1107,7 @@
         {
             await hubConnection.DisposeAsync();
         }
+
+        refreshLock.Dispose();
     }
 }

--- a/EsCQRSQuestions/EsCQRSQuestions.Web/Components/Pages/QuestionairJp.razor
+++ b/EsCQRSQuestions/EsCQRSQuestions.Web/Components/Pages/QuestionairJp.razor
@@ -1,6 +1,5 @@
 @page "/jp/questionair"
 @page "/jp/questionair/{UniqueCode}"
-@attribute [StreamRendering(true)]
 @using EsCQRSQuestions.Domain.Aggregates.Questions.Queries
 @using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.Extensions.Logging
@@ -392,8 +391,6 @@
                                 <div class="comment-composer">
                                     <input type="text" class="form-control comment-input" id="comment"
                                            @bind="comment" @bind:event="oninput" @onkeydown="HandleCommentKeyDown"
-                                           @oncompositionstart="OnCommentCompositionStart"
-                                           @oncompositionend="OnCommentCompositionEnd"
                                            placeholder="質問に関するコメントを入力" />
                                     <button class="btn btn-outline-primary comment-submit-btn"
                                             @onclick="SubmitCommentOnly"
@@ -502,7 +499,6 @@
     private bool hasSubmitted = false;
     private bool isSubmittingOption = false;
     private bool isSubmittingComment = false;
-    private bool isCommentComposing = false;
     private string inputUniqueCode = "";
     private bool isValidating = false;
     
@@ -511,6 +507,7 @@
     private CancellationTokenSource? autoRefreshCts;
     private Task? autoRefreshTask;
     private bool isAutoRefreshing;
+    private readonly SemaphoreSlim refreshLock = new(1, 1);
 
     // 前回のUniqueCodeを保存する変数
     private string? previousUniqueCode;
@@ -746,6 +743,7 @@
 
     private async Task RefreshActiveQuestion()
     {
+        await refreshLock.WaitAsync();
         try
         {
             
@@ -797,6 +795,10 @@
             {
                 errorMessage = "入力されたアンケートコードは存在しません。正しいコードを入力してください。";
             }
+        }
+        finally
+        {
+            refreshLock.Release();
         }
     }
 
@@ -1034,7 +1036,7 @@
     private async Task HandleCommentKeyDown(KeyboardEventArgs e)
     {
         // 日本語IME変換中(確定前)はEnterを送信扱いにしない
-        if (isCommentComposing || e.IsComposing)
+        if (e.IsComposing)
         {
             return;
         }
@@ -1043,16 +1045,6 @@
         {
             await SubmitCommentOnly();
         }
-    }
-
-    private void OnCommentCompositionStart()
-    {
-        isCommentComposing = true;
-    }
-
-    private void OnCommentCompositionEnd()
-    {
-        isCommentComposing = false;
     }
 
     private void StartAutoRefresh()
@@ -1112,5 +1104,7 @@
         {
             await hubConnection.DisposeAsync();
         }
+
+        refreshLock.Dispose();
     }
 }

--- a/EsCQRSQuestions/infrastructure/azure_container_apps/code_deploy_adminweb.sh
+++ b/EsCQRSQuestions/infrastructure/azure_container_apps/code_deploy_adminweb.sh
@@ -20,7 +20,11 @@ wait_for_containerapp_ready "$FRONTEND_APP_NAME"
 
 BACKEND_FQDN="$(get_containerapp_fqdn "$BACKEND_APP_NAME")"
 if [ -n "$BACKEND_FQDN" ]; then
-  API_BASE_URL="https://${BACKEND_FQDN}"
+  if [[ "$BACKEND_FQDN" == *".internal."* ]]; then
+    API_BASE_URL="http://${BACKEND_FQDN}"
+  else
+    API_BASE_URL="https://${BACKEND_FQDN}"
+  fi
 else
   API_BASE_URL="http://${BACKEND_APP_NAME}"
 fi

--- a/EsCQRSQuestions/infrastructure/azure_container_apps/code_deploy_frontend.sh
+++ b/EsCQRSQuestions/infrastructure/azure_container_apps/code_deploy_frontend.sh
@@ -18,7 +18,11 @@ build_and_push_image "$FRONTEND_PATH" "$IMAGE_NAME" "$TAG"
 wait_for_containerapp_ready "$BACKEND_APP_NAME"
 BACKEND_FQDN="$(get_containerapp_fqdn "$BACKEND_APP_NAME")"
 if [ -n "$BACKEND_FQDN" ]; then
-  API_BASE_URL="https://${BACKEND_FQDN}"
+  if [[ "$BACKEND_FQDN" == *".internal."* ]]; then
+    API_BASE_URL="http://${BACKEND_FQDN}"
+  else
+    API_BASE_URL="https://${BACKEND_FQDN}"
+  fi
 else
   API_BASE_URL="http://${BACKEND_APP_NAME}"
 fi


### PR DESCRIPTION
## Summary
- fix Safari circuit crash on survey pages by removing invalid composition event attributes
- keep IME-safe Enter handling via `KeyboardEventArgs.IsComposing` only
- harden ACA frontend/admin deploy scripts to use `http://` for internal backend FQDN and `https://` otherwise
- include participant-response domain artifacts used by current survey flow

## Validation
- `dotnet build /Users/tomohisa/dev/test/EsStudy0314/EsCQRSQuestions/EsCQRSQuestions.sln -v minimal`
- confirmed frontend deploy revision update on ACA
- confirmed DetailedErrors env vars removed from ad/fe container apps
